### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
 				<br><br>
 				We meet monthly to discuss current topics and best practices in OS X and iOS administration. It is a great opportunity to share issues and solutions with your fellow admins. A chance to find out what is and isn't working in other environments.
 				<br><br>
-				We have a good range of admins attending with representatives from small (20-50 users) and large (thousands of users) environments, to companies with offices throughout the world, universities and non for profit organisations.
+				We have a good range of admins attending with representatives from small (20-50 users) and large (thousands of users) environments, to companies with offices throughout the world, universities and not-for-profit organisations.
 				<br><br>
 				To see information about upcoming events and past events please click <a href="events.html">Events</a>
 				<br><br>


### PR DESCRIPTION
Changed "non for profit" (which is wrong all round) to "not-for-profit" which is correct for Australia. (https://www.acnc.gov.au/for-charities/start-charity/not-for-profit)

(I resisted inserting Oxford commas throughout. 😺 )